### PR TITLE
blsctl: Prevent printing backtrace when ran with insufficent permissions

### DIFF
--- a/blsctl/src/main.rs
+++ b/blsctl/src/main.rs
@@ -127,7 +127,11 @@ fn query_schema(config: &Configuration) -> color_eyre::Result<RootSchema> {
 }
 
 fn inspect_root(config: &Configuration) -> color_eyre::Result<()> {
-    check_permissions()?;
+    if let Err(e) = check_permissions() {
+        log::error!("{:#}", e);
+        return Ok(());
+    }
+
     let schema = query_schema(config)?;
     log::info!("Root Schema: {schema:?}");
 


### PR DESCRIPTION
Currently blsctl prints a backtrace and suggests submitting a bug report when ran with insufficient permissions.