### PR TITLE
Keep unique linux assets based on content hash

### DIFF
--- a/blsforme/src/bootloader/mod.rs
+++ b/blsforme/src/bootloader/mod.rs
@@ -21,11 +21,14 @@ pub enum Error {
     #[snafu(display("missing mountpoint: {description}"))]
     MissingMount { description: &'static str },
 
-    #[snafu(display("io: {source}"))]
-    Io { source: std::io::Error },
+    #[snafu(display("io: {context}: {source}"))]
+    Io { source: std::io::Error, context: String },
 
     #[snafu(display("wip: {source}"))]
     Prefix { source: StripPrefixError },
+
+    #[snafu(display("path missing final component: {path:?}"))]
+    MissingFinalComponent { path: PathBuf },
 }
 
 #[derive(Debug)]

--- a/blsforme/src/bootloader/systemd_boot/mod.rs
+++ b/blsforme/src/bootloader/systemd_boot/mod.rs
@@ -4,14 +4,17 @@
 
 //! systemd-boot management and interfaces
 
-use std::path::PathBuf;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use fs_err as fs;
 use snafu::{OptionExt as _, ResultExt as _};
 
 use crate::{
     Entry, GlobalCmdline, Kernel, Schema,
-    bootloader::{IoSnafu, MissingFileSnafu, MissingMountSnafu, PrefixSnafu},
+    bootloader::{IoSnafu, MissingFileSnafu, MissingFinalComponentSnafu, MissingMountSnafu, PrefixSnafu},
     file_utils::{PathExt, changed_files, copy_atomic_vfat},
     manager::Mounts,
 };
@@ -38,6 +41,9 @@ struct InstallResult {
 
     // The kernel path that was installed (absolute)
     kernel_dir: String,
+
+    // The image & initrd files installed under `kernel_dir` (absolute)
+    kernel_files: Vec<String>,
 }
 
 impl<'a, 'b> Loader<'a, 'b> {
@@ -98,29 +104,46 @@ impl<'a, 'b> Loader<'a, 'b> {
         ];
 
         for (source, dest) in changed_files(targets.as_slice()) {
-            copy_atomic_vfat(source, dest).context(IoSnafu)?;
+            copy_atomic_vfat(source, dest).context(IoSnafu {
+                context: "copy changed files",
+            })?;
         }
 
         // Write the loader.conf file with default entry pattern based on namespace
         let loader_conf_dir = self.boot_root.join_insensitive("loader");
         let loader_conf_path = loader_conf_dir.join_insensitive("loader.conf");
         if !loader_conf_dir.exists() {
-            fs::create_dir_all(loader_conf_dir).context(IoSnafu)?;
+            fs::create_dir_all(loader_conf_dir).context(IoSnafu {
+                context: "create loader conf dir",
+            })?;
         }
 
         // Create a default pattern that matches all entries for our namespace
         let namespace = self.schema.os_namespace();
         let default_pattern = format!("default \"{namespace}*\"\n");
-        fs::write(loader_conf_path, default_pattern).context(IoSnafu)?;
+        fs::write(loader_conf_path, default_pattern).context(IoSnafu {
+            context: "write loader.conf",
+        })?;
 
         Ok(())
     }
 
     pub(super) fn sync_entries(&self, cmdline: &GlobalCmdline, entries: &[Entry]) -> Result<(), super::Error> {
+        let mut hasher = blake3::Hasher::new();
         let mut installed_entries = vec![];
-        for entry in entries {
-            let full_cmdline = cmdline.full_cmdline(entry);
-            let installed = self.install(&full_cmdline, entry)?;
+
+        // Hash all assets installed by these entries
+        let hashed_entries = entries
+            .iter()
+            .map(|entry| EntryWithHashedAssets::new(&mut hasher, entry))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Compute the collisions between all entry assets so we can
+        // produce conflict-aware file names.
+        let collisions = AssetCollisions::from_entries(&hashed_entries);
+
+        for entry in &hashed_entries {
+            let installed = self.install(cmdline, &collisions, entry)?;
             installed_entries.push(installed);
         }
 
@@ -169,7 +192,7 @@ impl<'a, 'b> Loader<'a, 'b> {
         // Find all loader files that match any of our prefixes
         let mut loader_files = Vec::new();
         if let Ok(entries) = fs::read_dir(&loader_dir) {
-            for entry in entries.filter_map(|e| e.ok()) {
+            for entry in entries.flatten() {
                 let file_name = entry.file_name().to_string_lossy().to_string();
                 if all_prefixes.iter().any(|prefix| file_name.starts_with(prefix)) {
                     loader_files.push(entry.path());
@@ -178,15 +201,25 @@ impl<'a, 'b> Loader<'a, 'b> {
         }
 
         // Check each namespace for kernel directories
-        let mut kernel_dirs = Vec::new();
+        let mut kernel_files = HashMap::new();
         for namespace in &all_namespaces {
             let efi_dir = self.boot_root.join_insensitive("EFI").join_insensitive(namespace);
             if efi_dir.exists() {
                 if let Ok(entries) = fs::read_dir(&efi_dir) {
-                    for entry in entries.filter_map(|e| e.ok()) {
+                    for entry in entries.flatten() {
                         if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                            kernel_dirs.push(entry.path());
+                            kernel_files.insert(entry.path(), vec![]);
                         }
+                    }
+                }
+            }
+        }
+        // Add all files below each kernel directory
+        for (kernel_dir, files) in kernel_files.iter_mut() {
+            if let Ok(entries) = fs::read_dir(kernel_dir) {
+                for entry in entries.flatten() {
+                    if entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                        files.push(entry.path());
                     }
                 }
             }
@@ -197,9 +230,23 @@ impl<'a, 'b> Loader<'a, 'b> {
             .filter(|f| !installed_entries.iter().any(|e| e.loader_conf == f.to_string_lossy()))
             .collect::<Vec<_>>();
 
-        let obsolete_kernels = kernel_dirs
+        let obsolete_kernels = kernel_files
+            .keys()
+            .filter(|dir| !installed_entries.iter().any(|e| e.kernel_dir == dir.to_string_lossy()))
+            .collect::<Vec<_>>();
+
+        let obsolete_kernel_files = kernel_files
             .iter()
-            .filter(|f| !installed_entries.iter().any(|e| e.kernel_dir == f.to_string_lossy()))
+            .flat_map(|(dir, files)| {
+                let obsolete_kernels = &obsolete_kernels;
+                files.iter().filter(move |file| {
+                    // Already removing the entire dir
+                    !obsolete_kernels.contains(&dir)
+                        && !installed_entries
+                            .iter()
+                            .any(|e| e.kernel_files.contains(&file.to_string_lossy().to_string()))
+                })
+            })
             .collect::<Vec<_>>();
 
         for conf in obsolete_loader_confs.iter() {
@@ -216,48 +263,55 @@ impl<'a, 'b> Loader<'a, 'b> {
             }
         }
 
+        for file in obsolete_kernel_files.iter() {
+            log::info!("Removing stale kernel file: {file:?}");
+            if let Err(e) = fs::remove_file(file) {
+                log::error!("Failed to remove stale kernel file {file:?}: {e}")
+            }
+        }
+
         Ok(())
     }
 
     /// Install a kernel to the ESP or XBOOTLDR, write a config for it
-    fn install(&self, cmdline: &str, entry: &Entry) -> Result<InstallResult, super::Error> {
-        let effective_schema = entry.schema.as_ref().unwrap_or(self.schema);
+    fn install(
+        &self,
+        cmdline: &GlobalCmdline,
+        collisions: &AssetCollisions<'_>,
+        entry: &EntryWithHashedAssets<'_>,
+    ) -> Result<InstallResult, super::Error> {
+        let effective_schema = entry.inner.schema.as_ref().unwrap_or(self.schema);
 
         let loader_id = self
             .boot_root
             .join_insensitive("loader")
             .join_insensitive("entries")
-            .join_insensitive(format!("{}.conf", entry.id(effective_schema)));
+            .join_insensitive(format!("{}.conf", entry.inner.id(effective_schema)));
         log::trace!("writing entry: {}", loader_id.display());
 
-        let sysroot = &entry.sysroot;
+        let sysroot = &entry.inner.sysroot;
 
         // Get kernel directory for this specific entry
-        let kernel_dir = self.get_kernel_dir(entry);
+        let kernel_dir = self.get_kernel_dir(entry.inner);
 
         // vmlinuz primary path
-        let vmlinuz = kernel_dir.join_insensitive(
-            entry
-                .installed_kernel_name(effective_schema)
-                .context(MissingFileSnafu { filename: "vmlinuz" })?,
-        );
+        let vmlinuz = kernel_dir.join_insensitive(entry.image.installed_name(effective_schema, collisions));
         // initrds requiring install
         let initrds = entry
-            .kernel
             .initrd
             .iter()
-            .filter_map(|asset| {
-                Some((
-                    sysroot.join(&asset.path),
-                    kernel_dir.join_insensitive(entry.installed_asset_name(effective_schema, asset)?),
-                ))
+            .map(|initrd| {
+                (
+                    sysroot.join(initrd.path),
+                    kernel_dir.join_insensitive(initrd.installed_name(effective_schema, collisions)),
+                )
             })
             .collect::<Vec<_>>();
         log::trace!("with kernel path: {}", vmlinuz.display());
         log::trace!("with initrds: {initrds:?}");
 
         // build up the total changeset
-        let mut changeset = vec![(sysroot.join(&entry.kernel.image), vmlinuz.clone())];
+        let mut changeset = vec![(sysroot.join(entry.image.path), vmlinuz.clone())];
         changeset.extend(initrds);
 
         // Determine which need copying now.
@@ -266,7 +320,9 @@ impl<'a, 'b> Loader<'a, 'b> {
 
         // Donate them to disk
         for (source, dest) in needs_writing {
-            copy_atomic_vfat(source, dest).context(IoSnafu)?;
+            copy_atomic_vfat(source, dest).context(IoSnafu {
+                context: "copy changed files",
+            })?;
         }
 
         let asset_dir = kernel_dir
@@ -274,12 +330,15 @@ impl<'a, 'b> Loader<'a, 'b> {
             .context(PrefixSnafu)?
             .to_string_lossy();
 
-        let loader_config = self.generate_entry(&asset_dir, cmdline, entry);
+        let full_cmdline = cmdline.full_cmdline(entry.inner);
+        let loader_config = self.generate_entry(collisions, &asset_dir, &full_cmdline, entry);
         log::trace!("loader config: {loader_config}");
 
         let entry_dir = self.boot_root.join_insensitive("loader").join_insensitive("entries");
         if !entry_dir.exists() {
-            fs::create_dir_all(entry_dir).context(IoSnafu)?;
+            fs::create_dir_all(entry_dir).context(IoSnafu {
+                context: "create loader entries dir",
+            })?;
         }
 
         let tracker = InstallResult {
@@ -291,40 +350,51 @@ impl<'a, 'b> Loader<'a, 'b> {
                 })?
                 .to_string_lossy()
                 .to_string(),
+            kernel_files: changeset
+                .iter()
+                .map(|(_, path)| path.to_string_lossy().to_string())
+                .collect(),
         };
 
         // TODO: Hash compare and dont obliterate!
-        fs::write(loader_id, loader_config).context(IoSnafu)?;
+        fs::write(loader_id, loader_config).context(IoSnafu {
+            context: "write entry file",
+        })?;
 
         Ok(tracker)
     }
 
     /// Generate a usable loader config entry
-    fn generate_entry(&self, asset_dir: &str, cmdline: &str, entry: &Entry) -> String {
-        let effective_schema = entry.schema.as_ref().unwrap_or(self.schema);
+    fn generate_entry(
+        &self,
+        collisions: &AssetCollisions<'_>,
+        asset_dir: &str,
+        cmdline: &str,
+        entry: &EntryWithHashedAssets<'_>,
+    ) -> String {
+        let effective_schema = entry.inner.schema.as_ref().unwrap_or(self.schema);
 
-        let initrd = if entry.kernel.initrd.is_empty() {
+        let initrd = if entry.initrd.is_empty() {
             "\n".to_string()
         } else {
             let initrds = entry
-                .kernel
                 .initrd
                 .iter()
-                .filter_map(|asset| {
-                    Some(format!(
+                .map(|asset| {
+                    format!(
                         "\ninitrd /{asset_dir}/{}",
-                        entry.installed_asset_name(effective_schema, asset)?
-                    ))
+                        asset.installed_name(effective_schema, collisions)
+                    )
                 })
                 .collect::<String>();
             format!("\n{initrds}")
         };
         let title = if let Some(pretty) = effective_schema.os_display_name() {
-            format!("{pretty} ({})", entry.kernel.version)
+            format!("{pretty} ({})", entry.kernel_version())
         } else {
-            format!("{} ({})", effective_schema.os_name(), entry.kernel.version)
+            format!("{} ({})", effective_schema.os_name(), entry.kernel_version())
         };
-        let vmlinuz = entry.installed_kernel_name(effective_schema).expect("linux go boom");
+        let vmlinuz = entry.image.installed_name(effective_schema, collisions);
         format!(
             r###"title {title}
 linux /{asset_dir}/{vmlinuz}{initrd}
@@ -340,13 +410,25 @@ options {cmdline}
             .join_insensitive("EFI")
             .join_insensitive(self.schema.os_namespace());
 
-        for entry in fs::read_dir(&base_kernel_dir).context(IoSnafu)? {
-            let entry = entry.context(IoSnafu)?;
-            if !entry.file_type().context(IoSnafu)?.is_dir() {
+        for entry in fs::read_dir(&base_kernel_dir).context(IoSnafu {
+            context: "read kernel dirs",
+        })? {
+            let entry = entry.context(IoSnafu {
+                context: "read kernel dir entry",
+            })?;
+            if !entry
+                .file_type()
+                .context(IoSnafu {
+                    context: "get kernel dir entry file type",
+                })?
+                .is_dir()
+            {
                 continue;
             }
             let paths = fs::read_dir(entry.path())
-                .context(IoSnafu)?
+                .context(IoSnafu {
+                    context: "read kernel dir entries",
+                })?
                 .filter_map(|p| p.ok())
                 .map(|d| d.path())
                 .collect::<Vec<_>>();
@@ -357,6 +439,178 @@ options {cmdline}
             Ok(kernels)
         } else {
             Ok(vec![])
+        }
+    }
+}
+
+/// An [`Entry`] whose installable assets have been hashed for conflict-aware
+/// installation based on not only name, but content as well.
+struct EntryWithHashedAssets<'a> {
+    inner: &'a Entry<'a>,
+    image: HashedAsset<'a>,
+    initrd: Vec<HashedAsset<'a>>,
+}
+
+impl<'a> EntryWithHashedAssets<'a> {
+    fn new(hasher: &mut blake3::Hasher, entry: &'a Entry) -> Result<Self, super::Error> {
+        Ok(Self {
+            inner: entry,
+            image: HashedAsset::new(hasher, entry, HashedAssetKind::Image, &entry.kernel.image)?,
+            initrd: entry
+                .kernel
+                .initrd
+                .iter()
+                .map(|file| HashedAsset::new(hasher, entry, HashedAssetKind::Initrd, &file.path))
+                .collect::<Result<_, _>>()?,
+        })
+    }
+
+    fn kernel_version(&self) -> &'a str {
+        &self.inner.kernel.version
+    }
+}
+
+/// Unique asset key (kernel version + filename).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct AssetKey<'a> {
+    kernel_version: &'a str,
+    file_name: &'a str,
+}
+
+/// Tracks collisions between assets with the same [`AssetKey`],
+/// but different content. This can be used to query if the installed
+/// asset has a [`Self::conflict_index`], which can be used to ensure
+/// the installed asset filename doesn't collide w/ the other conflicts
+/// so that they all get installed instead of overwriting eachother.
+#[derive(Debug, Default)]
+struct AssetCollisions<'a> {
+    /// Map of all unique assets & the different hashes we've seen
+    /// for each (>1 == collision)
+    map: HashMap<AssetKey<'a>, Vec<blake3::Hash>>,
+}
+
+impl<'a> AssetCollisions<'a> {
+    /// Construct all collisions from the provided entries.
+    fn from_entries(entries: &'a [EntryWithHashedAssets<'a>]) -> Self {
+        let mut collisions = AssetCollisions::default();
+
+        for entry in entries {
+            collisions.insert(entry.image.key(), entry.image.blake3);
+
+            for initrd in &entry.initrd {
+                collisions.insert(initrd.key(), initrd.blake3);
+            }
+        }
+
+        collisions
+    }
+
+    fn insert(&mut self, key: AssetKey<'a>, hash: blake3::Hash) {
+        let hashes = self.map.entry(key).or_default();
+
+        if !hashes.contains(&hash) {
+            hashes.push(hash);
+        }
+    }
+
+    /// Returns a conflict index for the supplied asset if there are
+    /// collisions between this asset & others w/ the same [`AssetKey`],
+    /// but different content.
+    ///
+    /// This is a deterministic index that can be used to differentiate
+    /// this asset from its conflicts.
+    fn conflict_index(&self, asset: &HashedAsset<'_>) -> Option<usize> {
+        // Get all hashes seen for this asset
+        let hashes = self.map.get(&asset.key()).map(Vec::as_slice).unwrap_or_default();
+
+        // If we have conflicts (>1), get the conflict index of this hash
+        hashes
+            .iter()
+            .position(|hash| *hash == asset.blake3)
+            .filter(|_| hashes.len() > 1)
+    }
+}
+
+/// Type of asset
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HashedAssetKind {
+    Image,
+    Initrd,
+}
+
+/// An asset that has been content hashed.
+#[derive(Debug, Clone, Copy)]
+struct HashedAsset<'a> {
+    kind: HashedAssetKind,
+    kernel_version: &'a str,
+    path: &'a Path,
+    file_name: &'a str,
+    blake3: blake3::Hash,
+}
+
+impl<'a> HashedAsset<'a> {
+    fn new(
+        hasher: &mut blake3::Hasher,
+        entry: &'a Entry<'a>,
+        kind: HashedAssetKind,
+        path: &'a Path,
+    ) -> Result<Self, super::Error> {
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .context(MissingFinalComponentSnafu { path })?;
+        let full_path = entry.sysroot.join(path);
+
+        hasher.update_mmap_rayon(&full_path).context(IoSnafu {
+            context: format!("hash {full_path:?}"),
+        })?;
+        let blake3 = hasher.finalize();
+        hasher.reset();
+
+        Ok(Self {
+            kind,
+            kernel_version: &entry.kernel.version,
+            path,
+            file_name,
+            blake3,
+        })
+    }
+
+    /// The unique [`AssetKey`] for this asset.
+    fn key(&'a self) -> AssetKey<'a> {
+        AssetKey {
+            kernel_version: self.kernel_version,
+            file_name: self.file_name,
+        }
+    }
+
+    /// Generate an installed name for the asset, used by bootloaders.
+    ///
+    /// Non-legacy schemes will produce a context aware name to ensure
+    /// conflicting assets are both installed.
+    fn installed_name(&self, schema: &Schema, collisions: &AssetCollisions) -> String {
+        match schema {
+            Schema::Legacy { .. } => match self.kind {
+                // Need to add `kernel-`
+                HashedAssetKind::Image => format!("kernel-{}", self.file_name),
+                // Already has `initrd-` prefix
+                HashedAssetKind::Initrd => self.file_name.to_owned(),
+            },
+            _ => {
+                let conflict_suffix = collisions
+                    .conflict_index(self)
+                    .map(|index| format!(".{index}"))
+                    .unwrap_or_default();
+
+                match self.kind {
+                    HashedAssetKind::Image => {
+                        format!("{}/vmlinuz{conflict_suffix}", self.kernel_version)
+                    }
+                    HashedAssetKind::Initrd => {
+                        format!("{}/{}{conflict_suffix}", self.kernel_version, self.file_name)
+                    }
+                }
+            }
         }
     }
 }

--- a/blsforme/src/entry.rs
+++ b/blsforme/src/entry.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use crate::{AuxiliaryFile, Configuration, Kernel, Schema};
+use crate::{Configuration, Kernel, Schema};
 
 /// An entry corresponds to a single kernel, and may have a supplemental
 /// cmdline
@@ -83,48 +83,6 @@ impl<'a> Entry<'a> {
             format!("{id}-{version}-{state_id}", version = self.kernel.version)
         } else {
             format!("{id}-{version}", version = self.kernel.version)
-        }
-    }
-
-    /// Generate an installed name for the kernel, used by bootloaders
-    /// Right now this only returns CBM style IDs
-    pub fn installed_kernel_name(&self, schema: &Schema) -> Option<String> {
-        // Prefer internal schema if available
-        let effective_schema = self.schema.as_ref().unwrap_or(schema);
-
-        match effective_schema {
-            Schema::Legacy { .. } => self
-                .kernel
-                .image
-                .file_name()
-                .map(|f| f.to_string_lossy())
-                .map(|filename| format!("kernel-{filename}")),
-            _ => Some(format!("{}/vmlinuz", self.kernel.version)),
-        }
-    }
-
-    /// Generate installed asset (aux) name, used by bootloaders
-    /// Right now this only returns CBM style IDs
-    pub fn installed_asset_name(&self, schema: &Schema, asset: &AuxiliaryFile) -> Option<String> {
-        // Prefer internal schema if available
-        let effective_schema = self.schema.as_ref().unwrap_or(schema);
-
-        match effective_schema {
-            Schema::Legacy { .. } => match asset.kind {
-                crate::AuxiliaryKind::InitRd => asset
-                    .path
-                    .file_name()
-                    .map(|f| f.to_string_lossy())
-                    .map(|filename| format!("initrd-{filename}")),
-                _ => None,
-            },
-            _ => {
-                let filename = asset.path.file_name().map(|f| f.to_string_lossy())?;
-                match asset.kind {
-                    crate::AuxiliaryKind::InitRd => Some(format!("{}/{}", self.kernel.version, filename)),
-                    _ => None,
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Resolves #64 

This computes blake3 over all installable kernel files & ensures that "conflicts" (same file name / different hash) across entries get written out & linked so that we don't clobber a previous entry's assets w/ assets that have fundamentally changed within the same kernel version.

To ensure all conflicts get written out, we append a conflict id suffix to each file ONLY if conflicts exist. If no conflicts exist, the file has no suffix / looks as it did before.

The suffix is just a deterministic conflict id based on the stable sort of each conflicting assets blake3 hash -> its index into that conflict array. So rerunning will always produce the same suffix & linkage from the entry without leaking any implementation detail.

### Test

I've clobbered my current state initrd with `echo "1" >> /usr/lib/kernel/7.1.5-46.stable/50-default.initrd`. I have two states sharing this kernel version, so this should now produce 2 distinct assets & each entry should link to the correct one:

<img width="840" height="542" alt="image" src="https://github.com/user-attachments/assets/c0d7823c-be37-4efe-b550-695abefa091b" />


Looks good!