### PR TITLE
Refactor cmdline handling & fix ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "blake3",
  "fs-err",
  "gpt",
+ "itertools",
  "log",
  "nix",
  "os-info",
@@ -364,6 +365,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "env_logger"
@@ -660,6 +667,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ blake3 = { version = "1.6.0", features = ["mmap", "rayon"] }
 log = "0.4.26"
 fs-err = "3.1.1"
 gpt = "4.1.0"
+itertools = "0.15.0"
 thiserror = "2.0.11"
 nix = { version = "0.31.2", features = ["fs", "mount"] }
 os-info = { git = "https://github.com/AerynOS/os-info", rev = "26b39c1d49c3b4f30d778729fb56958824c069de" }

--- a/blsctl/src/main.rs
+++ b/blsctl/src/main.rs
@@ -185,14 +185,14 @@ fn inspect_root(config: &Configuration) -> color_eyre::Result<()> {
         }
     }
     log::info!("Kernels: {kernels:?}");
-    let mut entries = kernels.iter().map(Entry::new).collect::<Vec<_>>();
-    for entry in entries.iter_mut() {
-        entry.load_cmdline_snippets(config)?;
-    }
+    let entries = kernels
+        .iter()
+        .map(|kernel| Entry::new(config, kernel))
+        .collect::<Vec<_>>();
 
     // Query the manager
     let manager = Manager::new(config)?
-        .with_entries(entries.into_iter())
+        .with_entries(entries)
         .with_bootloader_assets(booty_bits);
     let _parts = manager.mount_partitions()?;
     eprintln!("manager = {manager:?}");

--- a/blsforme/Cargo.toml
+++ b/blsforme/Cargo.toml
@@ -5,13 +5,15 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+topology = { path = "../crates/topology" }
+
 blake3.workspace = true
+fs-err.workspace = true
+gpt.workspace = true
+itertools.workspace = true
 log.workspace = true
 nix.workspace = true
 os-info.workspace = true
-serde.workspace = true
 serde_json.workspace = true
+serde.workspace = true
 snafu.workspace = true
-topology = { path = "../crates/topology" }
-gpt.workspace = true
-fs-err.workspace = true

--- a/blsforme/src/bootloader/mod.rs
+++ b/blsforme/src/bootloader/mod.rs
@@ -8,7 +8,7 @@ use std::path::{PathBuf, StripPrefixError};
 
 use snafu::Snafu;
 
-use crate::{Entry, Firmware, Kernel, Schema, manager::Mounts};
+use crate::{Entry, Firmware, GlobalCmdline, Kernel, Schema, manager::Mounts};
 
 pub mod systemd_boot;
 
@@ -57,14 +57,9 @@ impl<'a, 'b> Bootloader<'a, 'b> {
         }
     }
 
-    pub fn sync_entries(
-        &self,
-        cmdline: impl Iterator<Item = &'a str>,
-        entries: &[Entry],
-        excluded_snippets: impl Iterator<Item = &'a str>,
-    ) -> Result<(), Error> {
+    pub fn sync_entries(&self, cmdline: &GlobalCmdline, entries: &[Entry]) -> Result<(), Error> {
         match &self {
-            Bootloader::Systemd(s) => s.sync_entries(cmdline, entries, excluded_snippets),
+            Bootloader::Systemd(s) => s.sync_entries(cmdline, entries),
         }
     }
 

--- a/blsforme/src/bootloader/systemd_boot/mod.rs
+++ b/blsforme/src/bootloader/systemd_boot/mod.rs
@@ -10,7 +10,7 @@ use fs_err as fs;
 use snafu::{OptionExt as _, ResultExt as _};
 
 use crate::{
-    Entry, Kernel, Schema,
+    Entry, GlobalCmdline, Kernel, Schema,
     bootloader::{IoSnafu, MissingFileSnafu, MissingMountSnafu, PrefixSnafu},
     file_utils::{PathExt, changed_files, copy_atomic_vfat},
     manager::Mounts,
@@ -116,29 +116,11 @@ impl<'a, 'b> Loader<'a, 'b> {
         Ok(())
     }
 
-    pub(super) fn sync_entries(
-        &self,
-        cmdline: impl Iterator<Item = &'a str>,
-        entries: &[Entry],
-        excluded_snippets: impl Iterator<Item = &'a str>,
-    ) -> Result<(), super::Error> {
-        let base_cmdline = cmdline.map(str::to_string).collect::<Vec<_>>();
-        let exclusions = excluded_snippets.map(str::to_string).collect::<Vec<_>>();
+    pub(super) fn sync_entries(&self, cmdline: &GlobalCmdline, entries: &[Entry]) -> Result<(), super::Error> {
         let mut installed_entries = vec![];
         for entry in entries {
-            let entry_cmdline = entry
-                .cmdline
-                .iter()
-                .filter(|c| !exclusions.contains(&c.name))
-                .map(|c| c.snippet.clone())
-                .collect::<Vec<_>>();
-            let full_cmdline = base_cmdline
-                .iter()
-                .chain(entry_cmdline.iter())
-                .cloned()
-                .collect::<Vec<_>>();
-
-            let installed = self.install(&full_cmdline.join(" "), entry)?;
+            let full_cmdline = cmdline.full_cmdline(entry);
+            let installed = self.install(&full_cmdline, entry)?;
             installed_entries.push(installed);
         }
 
@@ -248,7 +230,7 @@ impl<'a, 'b> Loader<'a, 'b> {
             .join_insensitive(format!("{}.conf", entry.id(effective_schema)));
         log::trace!("writing entry: {}", loader_id.display());
 
-        let sysroot = entry.sysroot.clone().unwrap_or_default();
+        let sysroot = &entry.sysroot;
 
         // Get kernel directory for this specific entry
         let kernel_dir = self.get_kernel_dir(entry);

--- a/blsforme/src/cmdline.rs
+++ b/blsforme/src/cmdline.rs
@@ -1,0 +1,160 @@
+use std::{io, path::Path};
+
+use fs_err as fs;
+use itertools::Itertools;
+use topology::disk::device::BlockDevice;
+
+use crate::{
+    Configuration, Entry, Kernel,
+    file_utils::{PathExt, read_dir_iter},
+};
+
+/// Global cmdline used as the basis for all boot entries.
+///
+/// This includes the `root=` related cmdline detected from
+/// the system's root [`BlockDevice`] and all local snippets
+/// loaded from `/etc`, including exclusions which will be
+/// used to filter out kernel specific cmdline.
+///
+/// This is used per [`Entry`] to form the final cmdline
+/// based on the loaded snippets for that entries kernel.
+#[derive(Debug, Default)]
+pub struct GlobalCmdline {
+    /// Cmdline containing root device.
+    root: [String; 2],
+    /// Cmdline snippets loaded from `/etc`.
+    etc_snippets: Vec<String>,
+    /// Cmdline exclusions loaded from `/etc`.
+    etc_exclusions: Vec<String>,
+}
+
+impl GlobalCmdline {
+    /// Returns a [`GlobalCmdline`] using the supplied [`BlockDevice`] for `root=`
+    /// and loading all snippets & exclusions from `/etc`.
+    pub fn new(config: &Configuration, root: &BlockDevice<'_>) -> Self {
+        log::info!("root = {:?}", root.cmd_line());
+
+        let (etc_snippets, etc_exclusions) = load_etc_cmdline(config);
+
+        Self {
+            root: [root.cmd_line(), "rw".to_owned()],
+            etc_snippets,
+            etc_exclusions,
+        }
+    }
+
+    /// The global cmdline string of this [`GlobalCmdline`].
+    pub fn cmdline(&self) -> String {
+        self.root.iter().chain(&self.etc_snippets).join(" ")
+    }
+
+    /// Merge all detected snippets into a full cmdline string for the supplied [`Entry`].
+    ///
+    /// Ordering:
+    ///
+    /// - root cmdline (root=)
+    /// - kernel cmdline w/out exclusions
+    /// - manually defined [`Entry`] cmdline
+    /// - /etc cmdline
+    pub fn full_cmdline(&self, entry: &Entry) -> String {
+        let kernel_cmdline = load_kernel_cmdline(&entry.sysroot, entry.kernel, &self.etc_exclusions);
+
+        self.root
+            .iter()
+            .chain(&kernel_cmdline)
+            .chain(&entry.cmdline)
+            .chain(&self.etc_snippets)
+            .join(" ")
+    }
+}
+
+/// Read a cmdline snippet from a file, which supports comments (`#`)
+/// and concatenates lines into a single string.
+fn cmdline_snippet(path: impl AsRef<Path>) -> io::Result<String> {
+    let path = path.as_ref();
+    log::trace!("Reading cmdline snippet: {path:?}");
+    let ret = fs::read_to_string(path)?
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.starts_with('#'))
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_string();
+    Ok(ret)
+}
+
+/// Loads all cmdline & exclusion snippets from `/etc`.
+fn load_etc_cmdline(config: &Configuration) -> (Vec<String>, Vec<String>) {
+    let mut snippets = vec![];
+    let mut exclusions = vec![];
+
+    let etc_cmdline_d = config.root.path().join("etc").join("kernel").join("cmdline.d");
+
+    let etc_entries = read_dir_iter(&etc_cmdline_d)
+        .flat_map(|entry| {
+            let path = entry.path();
+            path.extension().is_some_and(|e| e == "cmdline").then_some(path)
+        })
+        .collect::<Vec<_>>();
+
+    for entry in etc_entries {
+        // For anything that's a symlink to /dev/null, we'll exclude the matching system-wide cmdline
+        if entry.is_symlink()
+            && let Some(file_name) = entry.file_name_str()
+        {
+            if let Ok(target) = entry.read_link() {
+                if target.as_path() == Path::new("/dev/null") {
+                    log::trace!("excluding system-wide cmdline.d entry {entry:?}");
+                    exclusions.push(file_name.to_owned());
+                    continue;
+                }
+            }
+        }
+        if let Ok(c) = cmdline_snippet(entry) {
+            snippets.push(c);
+        }
+    }
+
+    (snippets, exclusions)
+}
+
+fn load_kernel_cmdline(sysroot: &Path, kernel: &Kernel, exclusions: &[String]) -> Vec<String> {
+    let mut snippets = vec![];
+
+    // Load local cmdline snippets for this kernel entry
+    for snippet in kernel
+        .extras
+        .iter()
+        .filter(|e| matches!(e.kind, crate::AuxiliaryKind::Cmdline))
+    {
+        let Some(file_name) = snippet.path.file_name_str() else {
+            continue;
+        };
+
+        // Only add if its not excluded
+        if !exclusions.contains(&file_name.to_owned()) {
+            snippets.extend(cmdline_snippet(sysroot.join(&snippet.path)));
+        }
+    }
+
+    // Globals
+    let cmdline_d = sysroot.join("usr").join("lib").join("kernel").join("cmdline.d");
+
+    if !cmdline_d.exists() {
+        return snippets;
+    }
+
+    for entry in read_dir_iter(&cmdline_d) {
+        let path = entry.path();
+        let Some(file_name) = path.file_name_str() else {
+            continue;
+        };
+
+        // Only add if its not excluded
+        if !exclusions.contains(&file_name.to_owned()) {
+            snippets.extend(cmdline_snippet(path));
+        }
+    }
+
+    snippets
+}

--- a/blsforme/src/entry.rs
+++ b/blsforme/src/entry.rs
@@ -4,20 +4,7 @@
 
 use std::path::PathBuf;
 
-use fs_err as fs;
-use snafu::ResultExt as _;
-
-use crate::{AuxiliaryFile, Configuration, IoSnafu, Kernel, Schema, file_utils::cmdline_snippet};
-
-/// A cmdline entry is found in the `$sysroot/usr/lib/kernel/cmdline.d` directory
-#[derive(Debug)]
-pub struct CmdlineEntry {
-    /// Name of the entry, i.e. `00-quiet.cmdline`
-    pub name: String,
-
-    /// Text contents of this cmdline entry
-    pub snippet: String,
-}
+use crate::{AuxiliaryFile, Configuration, Kernel, Schema};
 
 /// An entry corresponds to a single kernel, and may have a supplemental
 /// cmdline
@@ -25,9 +12,9 @@ pub struct CmdlineEntry {
 pub struct Entry<'a> {
     pub(crate) kernel: &'a Kernel,
 
-    pub(crate) sysroot: Option<PathBuf>,
+    pub(crate) sysroot: PathBuf,
 
-    pub(crate) cmdline: Vec<CmdlineEntry>,
+    pub(crate) cmdline: Vec<String>,
 
     /// Unique state ID for this entry
     pub(crate) state_id: Option<i32>,
@@ -38,60 +25,21 @@ pub struct Entry<'a> {
 
 impl<'a> Entry<'a> {
     /// New entry for the given kernel
-    pub fn new(kernel: &'a Kernel) -> Self {
+    pub fn new(config: &Configuration, kernel: &'a Kernel) -> Self {
         Self {
             kernel,
+            sysroot: config.root.path().to_owned(),
             cmdline: vec![],
-            sysroot: None,
             state_id: None,
             schema: None,
         }
     }
 
-    /// Load cmdline snippets from the system root for this entry's sysroot
-    pub fn load_cmdline_snippets(&mut self, config: &Configuration) -> Result<(), super::Error> {
-        let sysroot = self.sysroot.clone().unwrap_or(config.root.path().into());
-
-        // Load local cmdline snippets for this kernel entry
-        for snippet in self
-            .kernel
-            .extras
-            .iter()
-            .filter(|e| matches!(e.kind, crate::AuxiliaryKind::Cmdline))
-        {
-            if let Ok(cmdline) = cmdline_snippet(sysroot.join(&snippet.path)) {
-                self.cmdline.push(CmdlineEntry {
-                    name: snippet.path.file_name().unwrap().to_string_lossy().to_string(),
-                    snippet: cmdline,
-                });
-            }
-        }
-
-        // Globals
-        let cmdline_d = sysroot.join("usr").join("lib").join("kernel").join("cmdline.d");
-
-        if !cmdline_d.exists() {
-            return Ok(());
-        }
-
-        let entries = fs::read_dir(&cmdline_d).context(IoSnafu)?;
-
-        for entry in entries.filter_map(Result::ok) {
-            let name = entry.file_name().to_string_lossy().to_string();
-            // Don't bomb out on invalid cmdline snippets
-            if let Ok(snippet) = cmdline_snippet(entry.path()) {
-                self.cmdline.push(CmdlineEntry { name, snippet });
-            }
-        }
-
-        Ok(())
-    }
-
     /// With the given system root
-    /// This will cause any local snippets to be discovered
+    /// This affects where local snippets & files are loaded from
     pub fn with_sysroot(self, sysroot: impl Into<PathBuf>) -> Self {
         Self {
-            sysroot: Some(sysroot.into()),
+            sysroot: sysroot.into(),
             ..self
         }
     }
@@ -116,7 +64,7 @@ impl<'a> Entry<'a> {
 
     /// With the given cmdline entry
     /// Used by moss to inject a `moss.tx={}` parameter
-    pub fn with_cmdline(self, entry: CmdlineEntry) -> Self {
+    pub fn with_cmdline(self, entry: String) -> Self {
         let mut cmdline = self.cmdline;
         cmdline.push(entry);
         Self { cmdline, ..self }

--- a/blsforme/src/entry.rs
+++ b/blsforme/src/entry.rs
@@ -132,9 +132,9 @@ impl<'a> Entry<'a> {
             _ => effective_schema.os_id(),
         };
         if let Some(state_id) = self.state_id.as_ref() {
-            format!("{id}-{version}-{state_id}", version = &self.kernel.version)
+            format!("{id}-{version}-{state_id}", version = self.kernel.version)
         } else {
-            format!("{id}-{version}", version = &self.kernel.version)
+            format!("{id}-{version}", version = self.kernel.version)
         }
     }
 
@@ -173,7 +173,7 @@ impl<'a> Entry<'a> {
             _ => {
                 let filename = asset.path.file_name().map(|f| f.to_string_lossy())?;
                 match asset.kind {
-                    crate::AuxiliaryKind::InitRd => Some(format!("{}/{}", &self.kernel.version, filename)),
+                    crate::AuxiliaryKind::InitRd => Some(format!("{}/{}", self.kernel.version, filename)),
                     _ => None,
                 }
             }

--- a/blsforme/src/file_utils.rs
+++ b/blsforme/src/file_utils.rs
@@ -10,31 +10,38 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{Error, IoSnafu};
 use fs_err::{self as fs, File};
-use snafu::ResultExt as _;
 
-/// Case-insensitive path joining for FAT, respecting existing entries on the filesystem
-/// Note, this discards errors, so will require read permissions
-pub trait PathExt<P: AsRef<Path>> {
-    fn join_insensitive(&self, path: P) -> PathBuf;
+/// Path extensions
+pub trait PathExt {
+    /// Case-insensitive path joining for FAT, respecting existing entries on the filesystem
+    /// Note, this discards errors, so will require read permissions
+    fn join_insensitive<P: AsRef<Path>>(&self, path: P) -> PathBuf;
+    fn file_name_str(&self) -> Option<&str>;
 }
 
-impl<P: AsRef<Path>> PathExt<P> for PathBuf {
-    fn join_insensitive(&self, path: P) -> PathBuf {
+impl<T> PathExt for T
+where
+    T: AsRef<Path>,
+{
+    fn join_insensitive<P: AsRef<Path>>(&self, path: P) -> PathBuf {
         let real_path: &Path = path.as_ref();
-        if let Ok(dir) = fs::read_dir(self) {
+        if let Ok(dir) = fs::read_dir(self.as_ref()) {
             let entries = dir.filter_map(|e| e.ok()).filter_map(|p| {
                 let n = p.file_name();
                 n.into_string().ok()
             });
             for entry in entries {
                 if entry.to_lowercase() == real_path.to_string_lossy().to_lowercase() {
-                    return self.join(&entry);
+                    return self.as_ref().join(&entry);
                 }
             }
         }
-        self.join(path)
+        self.as_ref().join(path)
+    }
+
+    fn file_name_str(&self) -> Option<&str> {
+        self.as_ref().file_name().and_then(|name| name.to_str())
     }
 }
 
@@ -130,18 +137,10 @@ pub fn copy_atomic_vfat(source: impl AsRef<Path>, dest: impl AsRef<Path>) -> io:
     Ok(())
 }
 
-/// Read a cmdline snippet from a file, which supports comments (`#`)
-/// and concatenates lines into a single string.
-pub fn cmdline_snippet(path: impl AsRef<Path>) -> Result<String, Error> {
-    let path = path.as_ref();
-    log::trace!("Reading cmdline snippet: {path:?}");
-    let ret = fs::read_to_string(path)
-        .context(IoSnafu)?
-        .lines()
-        .map(|l| l.trim())
-        .filter(|l| !l.starts_with('#'))
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_string();
-    Ok(ret)
+/// Returns an iterator over the entries within `dir`.
+///
+/// All errors are flattened away, returning only the entries
+/// that could be successfully read.
+pub fn read_dir_iter(dir: &Path) -> impl Iterator<Item = fs::DirEntry> {
+    fs::read_dir(dir).into_iter().flat_map(|iter| iter.flatten())
 }

--- a/blsforme/src/lib.rs
+++ b/blsforme/src/lib.rs
@@ -8,25 +8,24 @@ use bootloader::systemd_boot;
 use gpt::GptError;
 use snafu::Snafu;
 
-mod kernel;
-pub use kernel::{AuxiliaryFile, AuxiliaryKind, BootJSON, Kernel, Schema};
-
-mod bootenv;
-pub use bootenv::{BootEnvironment, Firmware};
-pub mod bootloader;
-pub mod os_release;
-
-mod manager;
-pub use manager::Manager;
-
 /// Re-export the topology APIs
 pub use topology::disk;
 
-pub mod file_utils;
+pub use self::bootenv::{BootEnvironment, Firmware};
+pub use self::cmdline::GlobalCmdline;
+pub use self::entry::Entry;
+pub use self::kernel::{AuxiliaryFile, AuxiliaryKind, BootJSON, Kernel, Schema};
+pub use self::manager::Manager;
 
+mod bootenv;
+mod cmdline;
 mod entry;
+mod kernel;
+mod manager;
 
-pub use entry::{CmdlineEntry, Entry};
+pub mod bootloader;
+pub mod file_utils;
+pub mod os_release;
 
 /// Core error type for blsforme
 #[derive(Debug, Snafu)]

--- a/blsforme/src/manager.rs
+++ b/blsforme/src/manager.rs
@@ -12,8 +12,8 @@ use snafu::{ResultExt as _, ensure};
 use topology::disk;
 
 use crate::{
-    BootEnvironment, Configuration, Entry, Error, IoSnafu, Kernel, NixSnafu, Root, Schema, UnmountedEspSnafu,
-    bootloader::Bootloader, file_utils::cmdline_snippet,
+    BootEnvironment, Configuration, Entry, Error, GlobalCmdline, IoSnafu, Kernel, NixSnafu, Root, Schema,
+    UnmountedEspSnafu, bootloader::Bootloader,
 };
 
 #[derive(Debug)]
@@ -38,9 +38,7 @@ pub struct Manager<'a> {
 
     mounts: Mounts,
 
-    cmdline: Vec<String>,
-
-    system_excluded_snippets: Vec<String>,
+    global_cmdline: GlobalCmdline,
 }
 
 impl<'a> Manager<'a> {
@@ -49,40 +47,10 @@ impl<'a> Manager<'a> {
         // Probe the rootfs device managements
         let probe = disk::Builder::default().build()?;
         let root = probe.get_rootfs_device(config.root.path())?;
-        log::info!("root = {:?}", root.cmd_line());
 
-        // Right now we assume `rw` for the rootfs
-        let cmdline = [root.cmd_line(), "rw".to_string()];
-        let mut local_cmdline = vec![];
-
-        let etc_cmdline_d = config.root.path().join("etc").join("kernel").join("cmdline.d");
-        let etc_entries = fs::read_dir(&etc_cmdline_d)
-            .map(|i| {
-                i.filter_map(|p| p.ok())
-                    .filter(|d| d.path().extension().is_some_and(|e| e == "cmdline"))
-                    .map(|d| d.path().clone())
-            })
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        let mut system_excludes = vec![];
-
-        for entry in etc_entries {
-            // For anything that's a symlink to /dev/null, we'll exclude the matching system-wide cmdline
-            if entry.is_symlink() {
-                if let Ok(target) = entry.read_link() {
-                    if target == Path::new("/dev/null") {
-                        log::trace!("excluding system-wide cmdline.d entry {entry:?}");
-                        system_excludes.push(entry.file_name().unwrap_or_default().to_string_lossy().to_string());
-                        continue;
-                    }
-                }
-            }
-            // Ensure /etc cmdline.d entries are added to the end of the generated cmdline
-            if let Ok(c) = cmdline_snippet(entry) {
-                local_cmdline.push(c);
-            }
-        }
+        // Construct new global cmdline from the root block device
+        // and loaded /etc snippets.
+        let global_cmdline = GlobalCmdline::new(config, &root);
 
         // Grab parent disk, establish disk environment setup
         let disk_parent = probe.get_device_parent(root.path);
@@ -111,28 +79,25 @@ impl<'a> Manager<'a> {
             }
         }
 
-        let cmdline_joined = cmdline.into_iter().chain(local_cmdline).collect::<Vec<_>>();
-
         Ok(Self {
             config,
             entries: vec![],
             bootloader_assets: vec![],
             boot_env,
             mounts,
-            cmdline: cmdline_joined,
-            system_excluded_snippets: system_excludes,
+            global_cmdline,
         })
     }
 
-    /// Access the automatic cmdline
-    pub fn cmdline(&self) -> &[String] {
-        &self.cmdline
+    /// Access the global cmdline
+    pub fn global_cmdline(&self) -> String {
+        self.global_cmdline.cmdline()
     }
 
     /// Set the system kernels to use for sync operations
-    pub fn with_entries(self, entries: impl Iterator<Item = Entry<'a>>) -> Self {
+    pub fn with_entries(self, entries: impl IntoIterator<Item = Entry<'a>>) -> Self {
         Self {
-            entries: entries.collect::<Vec<_>>(),
+            entries: entries.into_iter().collect::<Vec<_>>(),
             ..self
         }
     }
@@ -215,11 +180,7 @@ impl<'a> Manager<'a> {
         bootloader.sync()?;
 
         // Sync the entries
-        bootloader.sync_entries(
-            self.cmdline.iter().map(String::as_str),
-            &self.entries,
-            self.system_excluded_snippets.iter().map(String::as_str),
-        )?;
+        bootloader.sync_entries(&self.global_cmdline, &self.entries)?;
 
         Ok(())
     }

--- a/blsforme/src/manager.rs
+++ b/blsforme/src/manager.rs
@@ -71,7 +71,7 @@ impl<'a> Manager<'a> {
             // For anything that's a symlink to /dev/null, we'll exclude the matching system-wide cmdline
             if entry.is_symlink() {
                 if let Ok(target) = entry.read_link() {
-                    if target == PathBuf::from("/dev/null") {
+                    if target == Path::new("/dev/null") {
                         log::trace!("excluding system-wide cmdline.d entry {entry:?}");
                         system_excludes.push(entry.file_name().unwrap_or_default().to_string_lossy().to_string());
                         continue;

--- a/crates/topology/src/disk/device.rs
+++ b/crates/topology/src/disk/device.rs
@@ -121,7 +121,7 @@ impl<'a> BlockDevice<'a> {
                 }
             }
         } else if !self.aux {
-            format!("root={}", &self.path)
+            format!("root={}", self.path)
         } else {
             String::new()
         };

--- a/crates/topology/src/disk/probe.rs
+++ b/crates/topology/src/disk/probe.rs
@@ -58,7 +58,7 @@ impl Probe {
             let matching_device = self
                 .mounts
                 .iter()
-                .find(|m| PathBuf::from(m.mountpoint) == mountpoint)
+                .find(|m| Path::new(m.mountpoint) == mountpoint)
                 .ok_or(super::Error::UnknownMount { path: mountpoint })?;
             // TODO: Handle `ZFS=`, and composite bcachefs mounts (dev:dev1:dev2)
             Ok(matching_device.device.into())


### PR DESCRIPTION
Previously cmdline loading was happening in many parts of the codebase. This refactors to a cmdline module which is the source of truth for all cmdline loading & final merge logic.

This also fixes a bug where `/etc` cmdline snippets were added _before_ `/usr` kernel specific cmdline instead of after.

### Testing

Before & after for `boot status`. Global cmdline is the same, but now we just show it as the merged string:

<img width="840" height="212" alt="image" src="https://github.com/user-attachments/assets/c9e819b4-d700-4e7e-88bf-d9b1b794dafe" />

Before & after for my latest boot entry :

<img width="840" height="355" alt="image" src="https://github.com/user-attachments/assets/3132395e-c32e-4cde-b390-e12407765dbb" />

Notice my custom `nvme_core` entry is last. Also notice `moss.fstx` comes AFTER `quiet splash`. This is because this is added by moss manually which I feel follows a similar order of priorty ruling where it should be higher than the shipped cmdline.