### PR TITLE
Add shared initrd handling for blsforme schemes

### DIFF
--- a/blsforme/src/bootloader/systemd_boot/mod.rs
+++ b/blsforme/src/bootloader/systemd_boot/mod.rs
@@ -13,9 +13,9 @@ use fs_err as fs;
 use snafu::{OptionExt as _, ResultExt as _};
 
 use crate::{
-    Entry, GlobalCmdline, Kernel, Schema,
+    AuxiliaryKind, Entry, GlobalCmdline, Kernel, Schema,
     bootloader::{IoSnafu, MissingFileSnafu, MissingFinalComponentSnafu, MissingMountSnafu, PrefixSnafu},
-    file_utils::{PathExt, changed_files, copy_atomic_vfat},
+    file_utils::{PathExt, changed_files, copy_atomic_vfat, read_dir_iter},
     manager::Mounts,
 };
 
@@ -191,12 +191,10 @@ impl<'a, 'b> Loader<'a, 'b> {
 
         // Find all loader files that match any of our prefixes
         let mut loader_files = Vec::new();
-        if let Ok(entries) = fs::read_dir(&loader_dir) {
-            for entry in entries.flatten() {
-                let file_name = entry.file_name().to_string_lossy().to_string();
-                if all_prefixes.iter().any(|prefix| file_name.starts_with(prefix)) {
-                    loader_files.push(entry.path());
-                }
+        for entry in read_dir_iter(&loader_dir) {
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            if all_prefixes.iter().any(|prefix| file_name.starts_with(prefix)) {
+                loader_files.push(entry.path());
             }
         }
 
@@ -204,23 +202,22 @@ impl<'a, 'b> Loader<'a, 'b> {
         let mut kernel_files = HashMap::new();
         for namespace in &all_namespaces {
             let efi_dir = self.boot_root.join_insensitive("EFI").join_insensitive(namespace);
-            if efi_dir.exists() {
-                if let Ok(entries) = fs::read_dir(&efi_dir) {
-                    for entry in entries.flatten() {
-                        if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                            kernel_files.insert(entry.path(), vec![]);
-                        }
-                    }
+
+            if !efi_dir.exists() {
+                continue;
+            }
+
+            for entry in read_dir_iter(&efi_dir) {
+                if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                    kernel_files.insert(entry.path(), vec![]);
                 }
             }
         }
         // Add all files below each kernel directory
         for (kernel_dir, files) in kernel_files.iter_mut() {
-            if let Ok(entries) = fs::read_dir(kernel_dir) {
-                for entry in entries.flatten() {
-                    if entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
-                        files.push(entry.path());
-                    }
+            for entry in read_dir_iter(kernel_dir) {
+                if entry.file_type().is_ok_and(|t| t.is_file()) {
+                    files.push(entry.path());
                 }
             }
         }
@@ -232,7 +229,17 @@ impl<'a, 'b> Loader<'a, 'b> {
 
         let obsolete_kernels = kernel_files
             .keys()
-            .filter(|dir| !installed_entries.iter().any(|e| e.kernel_dir == dir.to_string_lossy()))
+            .filter(|dir| {
+                // Don't cleanup shared dir if used by this scheme
+                if dir.file_name_str().unwrap_or_default() == "shared"
+                    && matches!(self.schema, Schema::Blsforme { .. } | Schema::OsInfo { .. })
+                {
+                    return false;
+                }
+
+                // Remove kernel dirs that have no more matching entries
+                !installed_entries.iter().any(|e| e.kernel_dir == dir.to_string_lossy())
+            })
             .collect::<Vec<_>>();
 
         let obsolete_kernel_files = kernel_files
@@ -460,7 +467,15 @@ impl<'a> EntryWithHashedAssets<'a> {
                 .kernel
                 .initrd
                 .iter()
-                .map(|file| HashedAsset::new(hasher, entry, HashedAssetKind::Initrd, &file.path))
+                .filter_map(|file| {
+                    let kind = match file.kind {
+                        AuxiliaryKind::VersionedInitRd => HashedAssetKind::VersionedInitrd,
+                        AuxiliaryKind::SharedInitRd => HashedAssetKind::SharedInitrd,
+                        _ => return None,
+                    };
+
+                    Some(HashedAsset::new(hasher, entry, kind, &file.path))
+                })
                 .collect::<Result<_, _>>()?,
         })
     }
@@ -470,10 +485,21 @@ impl<'a> EntryWithHashedAssets<'a> {
     }
 }
 
-/// Unique asset key (kernel version + filename).
+/// The scope determines which folder the asset
+/// will be installed into, under which it must
+/// have a unique filename.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum AssetScope<'a> {
+    /// Scoped to a kernel version
+    Versioned(&'a str),
+    /// Shared across any kernel
+    Shared,
+}
+
+/// Unique asset key (scope + filename).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct AssetKey<'a> {
-    kernel_version: &'a str,
+    scope: AssetScope<'a>,
     file_name: &'a str,
 }
 
@@ -535,7 +561,8 @@ impl<'a> AssetCollisions<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HashedAssetKind {
     Image,
-    Initrd,
+    VersionedInitrd,
+    SharedInitrd,
 }
 
 /// An asset that has been content hashed.
@@ -578,8 +605,14 @@ impl<'a> HashedAsset<'a> {
 
     /// The unique [`AssetKey`] for this asset.
     fn key(&'a self) -> AssetKey<'a> {
+        let scope = if matches!(self.kind, HashedAssetKind::SharedInitrd) {
+            AssetScope::Shared
+        } else {
+            AssetScope::Versioned(self.kernel_version)
+        };
+
         AssetKey {
-            kernel_version: self.kernel_version,
+            scope,
             file_name: self.file_name,
         }
     }
@@ -594,7 +627,7 @@ impl<'a> HashedAsset<'a> {
                 // Need to add `kernel-`
                 HashedAssetKind::Image => format!("kernel-{}", self.file_name),
                 // Already has `initrd-` prefix
-                HashedAssetKind::Initrd => self.file_name.to_owned(),
+                HashedAssetKind::VersionedInitrd | HashedAssetKind::SharedInitrd => self.file_name.to_owned(),
             },
             _ => {
                 let conflict_suffix = collisions
@@ -606,8 +639,11 @@ impl<'a> HashedAsset<'a> {
                     HashedAssetKind::Image => {
                         format!("{}/vmlinuz{conflict_suffix}", self.kernel_version)
                     }
-                    HashedAssetKind::Initrd => {
+                    HashedAssetKind::VersionedInitrd => {
                         format!("{}/{}{conflict_suffix}", self.kernel_version, self.file_name)
+                    }
+                    HashedAssetKind::SharedInitrd => {
+                        format!("shared/{}{conflict_suffix}", self.file_name)
                     }
                 }
             }

--- a/blsforme/src/kernel.rs
+++ b/blsforme/src/kernel.rs
@@ -11,7 +11,7 @@ use std::{
 
 use serde::Deserialize;
 
-use crate::{Error, os_release::OsRelease};
+use crate::{Error, file_utils::PathExt, os_release::OsRelease};
 use os_info::OsInfo;
 
 /// Control kernel discovery mechanism
@@ -82,8 +82,11 @@ pub enum AuxiliaryKind {
     /// A cmdline snippet
     Cmdline,
 
-    /// An initial ramdisk
-    InitRd,
+    /// A versioned initial ramdisk
+    VersionedInitRd,
+
+    /// A shared initial ramdisk
+    SharedInitRd,
 
     /// System.map file
     SystemMap,
@@ -228,14 +231,14 @@ impl Schema {
                     }),
                     x if x == initrd_file => Some(AuxiliaryFile {
                         path: path.as_ref().into(),
-                        kind: AuxiliaryKind::InitRd,
+                        kind: AuxiliaryKind::VersionedInitRd,
                     }),
                     x if x.starts_with(&initrd_file) => {
                         // Version dependent initrd
                         if x != initrd_file && x.split_once(&initrd_file).is_some() {
                             Some(AuxiliaryFile {
                                 path: path.as_ref().into(),
-                                kind: AuxiliaryKind::InitRd,
+                                kind: AuxiliaryKind::VersionedInitRd,
                             })
                         } else {
                             None
@@ -247,7 +250,7 @@ impl Schema {
                             if !r.contains('.') {
                                 Some(AuxiliaryFile {
                                     path: path.as_ref().into(),
-                                    kind: AuxiliaryKind::InitRd,
+                                    kind: AuxiliaryKind::SharedInitRd,
                                 })
                             } else {
                                 None
@@ -260,7 +263,10 @@ impl Schema {
                 };
 
                 if let Some(aux_file) = aux {
-                    if matches!(aux_file.kind, AuxiliaryKind::InitRd) {
+                    if matches!(
+                        aux_file.kind,
+                        AuxiliaryKind::VersionedInitRd | AuxiliaryKind::SharedInitRd
+                    ) {
                         kernel.initrd.push(aux_file);
                     } else {
                         kernel.extras.push(aux_file);
@@ -303,15 +309,10 @@ impl Schema {
 
         // Walk kernels, find matching assets
         for (version, kernel) in kernel_images.iter_mut() {
-            let lepath = kernel
-                .image
-                .parent()
-                .ok_or(Error::InvalidFilesystem)?
-                .to_str()
-                .ok_or(Error::InvalidFilesystem)?;
+            let kernel_dir = kernel.image.parent().ok_or(Error::InvalidFilesystem)?;
             let versioned_assets = all_paths
                 .iter()
-                .filter(|p| !p.ends_with("vmlinuz") && p.starts_with(lepath) && !p.ends_with(version));
+                .filter(|p| !p.ends_with("vmlinuz") && p.starts_with(kernel_dir) && !p.ends_with(version));
             for asset in versioned_assets {
                 let filename = asset
                     .file_name()
@@ -331,9 +332,16 @@ impl Schema {
                         path: asset.clone(),
                         kind: AuxiliaryKind::Config,
                     }),
+                    // Older paradigm used before we had proper shared initrd support.
+                    // `-shared.initrd` files were placed beneath the versioned kernel
+                    // directory so they'd get picked up, but not deduplicated.
+                    _ if filename.ends_with("-shared.initrd") => Some(AuxiliaryFile {
+                        path: asset.clone(),
+                        kind: AuxiliaryKind::SharedInitRd,
+                    }),
                     _ if filename.ends_with(".initrd") => Some(AuxiliaryFile {
                         path: asset.clone(),
-                        kind: AuxiliaryKind::InitRd,
+                        kind: AuxiliaryKind::VersionedInitRd,
                     }),
                     _ if filename.ends_with(".cmdline") => Some(AuxiliaryFile {
                         path: asset.clone(),
@@ -343,20 +351,57 @@ impl Schema {
                 };
 
                 if let Some(aux_file) = aux {
-                    if matches!(aux_file.kind, AuxiliaryKind::InitRd) {
+                    if matches!(
+                        aux_file.kind,
+                        AuxiliaryKind::VersionedInitRd | AuxiliaryKind::SharedInitRd
+                    ) {
                         kernel.initrd.push(aux_file);
                     } else {
                         kernel.extras.push(aux_file);
                     }
                 }
+            }
 
+            // Add all shared init.rd files from `initrd.d`. Due to how we used to ship
+            // shared initrd files under the versioned kernel dir, anything here should
+            // "override" a matching file found from that dir. It existing here is
+            // hard confirmation this is a shared initrd filename.
+            let Some(initrd_d) = kernel_dir.parent().map(|p| p.join("initrd.d")) else {
+                continue;
+            };
+            let shared_initrd_assets = all_paths
+                .iter()
+                .filter(|p| p.starts_with(&initrd_d) && p.file_name_str().unwrap_or_default().ends_with(".initrd"));
+            for asset in shared_initrd_assets {
+                let filename = asset
+                    .file_name()
+                    .ok_or(Error::InvalidFilesystem)?
+                    .to_str()
+                    .ok_or(Error::InvalidFilesystem)?;
+
+                // If a shared initrd collides w/ an initrd found in the versioned kernel
+                // dir, remove the versioned initrd since those were the old hacky way
+                // of shipping shared initrd & we don't want to add them twice.
                 kernel
                     .initrd
-                    .sort_by_key(|i| i.path.display().to_string().to_lowercase());
-                kernel
-                    .extras
-                    .sort_by_key(|e| e.path.display().to_string().to_lowercase());
+                    .retain(|file| file.path.file_name_str().unwrap_or_default() != filename);
+
+                kernel.initrd.push(AuxiliaryFile {
+                    path: asset.to_owned(),
+                    kind: AuxiliaryKind::SharedInitRd,
+                });
             }
+
+            // Sort by file name, not path, since assets can exist between the
+            // `shared` directory and the versioned kernel directory. The filename
+            // should have the `NN-` prefix for determining the order for how
+            // assets should be loaded.
+            kernel
+                .initrd
+                .sort_by_key(|i| i.path.file_name_str().unwrap_or_default().to_lowercase());
+            kernel
+                .extras
+                .sort_by_key(|e| e.path.file_name_str().unwrap_or_default().to_lowercase());
         }
 
         Ok(kernel_images.into_values().collect::<Vec<_>>())


### PR DESCRIPTION
Shared (version independent) initrd files can be deduplicated across multiple kernels. This adds support to identify when initrds are shared vs versioned and for the newer blsforme schemes, it places those assets beneath a "shared" directory that allows deduplication. 

This adds logic to detect shared initrd files in two different ways:

- `kernel/{version}/foo-shared.initrd` / `-shared.initrd` suffixed files in the versioned kernel directory.
- `kernel/initrd.d/foo.initrd` / All `.initrd` extension files in the `initrd.d` directory.

Any filenames that get matched from `initrd.d` will take priority over filenames from a versioned kernel directory to handle migration from the older scheme to the newer `initrd.d` scheme.

### Testing

I've installed the two packages that have shared initrd files:

<img width="836" height="560" alt="image" src="https://github.com/user-attachments/assets/b77c466f-9e8a-440c-9408-818495406e15" />

And also tested our collision logic applies to these assets as well:

<img width="522" height="560" alt="image" src="https://github.com/user-attachments/assets/fb76dcb0-0e92-4ee9-9851-dcd9d15caec5" />

Boom!